### PR TITLE
Fix title description text in 'What can you do' block (#302)

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -23,7 +23,7 @@
   },
   "whatCanYouDo": {
     "title": "What can you do",
-    "description": "Whether you’re looking for a tutor or to looking become one – you’ve come to the right place.",
+    "description": "Whether you’re looking for a tutor or looking to become one – you’ve come to the right place.",
     "learn": {
       "title": "Learn from experts",
       "description": "Learning from experts is a shortcut to mastery. Their knowledge and experience can guide you, unlocking your potential. Don't put off until tomorrow. Embrace it! 🌟",


### PR DESCRIPTION
Fixed the text in the "What can you do" block on the home page to match the mockup as per issue #302.