### PR TITLE
The placeholder text is not corresponded to the mockup in the “Interests” page #310

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -13,7 +13,7 @@
     "autocompleteLabel": "Your native language"
   },
   "categories": {
-    "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
+    "title": "Please choose the main subjects based on the category.You can add others later.",
     "mainSubjectsLabel": "Main Tutoring Category",
     "subjectLabel": "Subject",
     "btnText": "Add one more subject",

--- a/src/constants/translations/ua/become-tutor.json
+++ b/src/constants/translations/ua/become-tutor.json
@@ -19,7 +19,7 @@
     "autocompleteLabel": "Твоя рідна мова"
   },
   "categories": {
-    "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
+    "title": "Будь ласка, виберіть основні предмети на основі категорії. Ви можете додати інші пізніше.",
     "mainSubjectsLabel": "Основна категорія предмету",
     "subjectLabel": "Предмет",
     "btnText": "Додайте ще один предмет",


### PR DESCRIPTION
Fix placeholder text on the "Interests" page.
Fixes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated translation text for tutor category selection in English and Ukrainian languages
	- Refined user guidance for selecting main subjects during tutor registration
	- Clarified that additional subjects can be added later in account settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->