### PR TITLE
The placeholder text is not corresponded to the mockup in the “Subjects” page #309

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -14,7 +14,7 @@
   },
   "categories": {
     "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
-    "mainSubjectsLabel": "Main Tutoring Category",
+    "mainSubjectsLabel": "Main Study Category",
     "subjectLabel": "Subject",
     "btnText": "Add one more subject",
     "emptyFields": "All fields must be filled",


### PR DESCRIPTION
Fix placeholder text on the "Subjects" page.
Fixes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated terminology in translation file from "Main Tutoring Category" to "Main Study Category"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->