### PR TITLE
The text "Already have a Space2Study account? Log In" doesn't correspond the requirements #307

### DIFF
--- a/src/constants/translations/en/signup.json
+++ b/src/constants/translations/en/signup.json
@@ -7,7 +7,7 @@
   "and": "and",
   "googleButton": "Sign up with Google",
   "continue": "or continue",
-  "haveAccount": "Already have a tutor account?",
+  "haveAccount": "Already have a Space2Study account?",
   "joinUs": "Login!",
   "confirmEmailTitle": "Your email address needs to be verified",
   "confirmEmailMessage": "We sent a confirmation email to: ",


### PR DESCRIPTION
Fix the text "Already have a tutor account?"  to "Already have a Space2Study account?" on the "Sign Up" pop-up. 
Fixes #307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated signup page text to reference "Space2Study" account instead of "tutor" account
	- Refined user interface terminology for improved clarity and brand consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->