### PR TITLE
Write tests for question editor component #192

### DIFF
--- a/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -1,0 +1,112 @@
+import { screen, render, fireEvent } from '@testing-library/react'
+import QuestionEditor from '~/components/question-editor/QuestionEditor'
+
+const mockedQuestion = {
+  title: 'About Philosophy',
+  text: 'Who created buddhism?',
+  answers: [
+    {
+      id: '1',
+      text: 'Buddha Shakyamuni',
+      isCorrect: true
+    },
+    {
+      id: '2',
+      text: 'Jordan Belfort',
+      isCorrect: false
+    }
+  ],
+  type: 'oneAnswer',
+  category: {
+    _id: 'some-text-id-123',
+    name: 'Philosophy'
+  }
+}
+
+const mockedQuestionWithOpenAnswer = {
+  type: 'openAnswer',
+  text: 'Who created buddhism?',
+  answers: [],
+  openAnswer: 'Test'
+}
+
+const handleInputChangeMock = vi.fn()
+const handleNonInputValueChangeMock = vi.fn()
+
+describe('QuestionEditor', () => {
+  it('should renders question input field', () => {
+    render(
+      <QuestionEditor
+        data={mockedQuestion}
+        handleInputChange={handleInputChangeMock}
+        handleNonInputValueChange={handleNonInputValueChangeMock}
+      />
+    )
+
+    const questionInput = screen.getByRole('textbox', { name: /question/i })
+
+    expect(questionInput).toBeInTheDocument()
+    expect(questionInput).toHaveValue(mockedQuestion.text)
+  })
+
+  it('should renders a open answer', () => {
+    render(
+      <QuestionEditor
+        data={mockedQuestionWithOpenAnswer}
+        handleInputChange={handleInputChangeMock}
+        handleNonInputValueChange={handleNonInputValueChangeMock}
+      />
+    )
+
+    const openAnswerInput = screen.getByRole('textbox', { name: /answer/i })
+
+    expect(openAnswerInput).toBeInTheDocument()
+    expect(openAnswerInput).toHaveValue(mockedQuestionWithOpenAnswer.openAnswer)
+  })
+
+  it('should change question type', () => {
+    render(
+      <QuestionEditor
+        data={mockedQuestion}
+        handleInputChange={handleInputChangeMock}
+        handleNonInputValueChange={handleNonInputValueChangeMock}
+      />
+    )
+
+    const selectInput = screen.getByTestId('app-select')
+    fireEvent.change(selectInput, { target: { value: 'multipleChoice' } })
+
+    expect(handleNonInputValueChangeMock).toHaveBeenCalledWith(
+      'type',
+      'multipleChoice'
+    )
+  })
+
+  it('should change question input field', () => {
+    render(
+      <QuestionEditor
+        data={mockedQuestion}
+        handleInputChange={handleInputChangeMock}
+        handleNonInputValueChange={handleNonInputValueChangeMock}
+      />
+    )
+    const questionInput = screen.getByRole('textbox', { name: /question/i })
+    fireEvent.change(questionInput, { target: { value: 'New question' } })
+
+    expect(handleInputChangeMock).toHaveBeenCalledWith('text')
+  })
+
+  it('should change answer input field', () => {
+    render(
+      <QuestionEditor
+        data={mockedQuestionWithOpenAnswer}
+        handleInputChange={handleInputChangeMock}
+        handleNonInputValueChange={handleNonInputValueChangeMock}
+      />
+    )
+    const openAnswerInput = screen.getByRole('textbox', { name: /answer/i })
+    fireEvent.change(openAnswerInput, { target: { value: 'New answer' } })
+
+    expect(handleInputChangeMock).toHaveBeenCalledWith('openAnswer')
+  })
+})


### PR DESCRIPTION
Write tests for "Question Editor" component.

The "it should click on edit title and category" part was not implemented as it belongs to the "CreateOrEditQuizContainer" component. A separate task will be created to write the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added comprehensive unit tests for the `QuestionEditor` component
	- Verified rendering of question input fields
	- Tested handling of different question types and input changes
	- Ensured correct callback invocations during user interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->