### PR TITLE
Write tests for range component (#189)

### DIFF
--- a/src/tests/unit/components/app-range/AppRange.spec.jsx
+++ b/src/tests/unit/components/app-range/AppRange.spec.jsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AppRange from '~/components/app-range/AppRange'
+
+const onChangeMock = vi.fn()
+
+const propsMock = {
+  min: 0,
+  max: 100,
+  onChange: onChangeMock,
+  value: [10, 50]
+}
+
+describe('AppRange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    render(<AppRange {...propsMock} />)
+  })
+
+  it('should renders correctly', () => {
+    const inputs = screen.getAllByRole('textbox')
+    expect(inputs[0]).toHaveValue('10')
+    expect(inputs[1]).toHaveValue('50')
+
+    const sliders = screen.getAllByRole('slider')
+    expect(sliders[0]).toHaveAttribute('min', '0')
+    expect(sliders[0]).toHaveAttribute('max', '100')
+
+    expect(screen.getByText(/from/i)).toBeInTheDocument()
+    expect(screen.getByText(/to/i)).toBeInTheDocument()
+  })
+
+  it('it should call onChange when slider is moved', async () => {
+    const sliders = screen.getAllByRole('slider')
+    fireEvent.change(sliders[0], { target: { value: 17 } })
+
+    expect(sliders[0].value).toBe('17')
+    await waitFor(() => {
+      expect(onChangeMock).toHaveBeenCalled('17')
+    })
+  })
+
+  it('it should call onChange when input is changed', async () => {
+    const inputs = screen.getAllByRole('textbox')
+
+    await userEvent.clear(inputs[0])
+    await userEvent.type(inputs[0], '20')
+
+    await waitFor(() => {
+      expect(onChangeMock).toHaveBeenCalledWith([20, 50])
+    })
+  })
+
+  it('it should not call onChange when input is changed with not a number', async () => {
+    const inputs = screen.getAllByRole('textbox')
+
+    await userEvent.clear(inputs[0])
+    await userEvent.type(inputs[0], 'NaN')
+
+    await waitFor(() => {
+      expect(onChangeMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it('should call onChange with min number if input is empty', async () => {
+    const inputs = screen.getAllByRole('textbox')
+
+    await userEvent.clear(inputs[0])
+    await userEvent.tab()
+
+    await waitFor(() => {
+      expect(onChangeMock).toHaveBeenCalledWith([propsMock.min, 50])
+    })
+  })
+
+  //   it('should update prices when input is blurred and input is greater than max value', async () => {
+  //     const inputs = screen.getAllByRole('textbox')
+
+  //     await userEvent.clear(inputs[1])
+  //     await userEvent.type(inputs[1], '1500000')
+  //     await userEvent.tab()
+
+  //     expect(inputs[1]).not.toHaveFocus()
+
+  //     expect(inputs[1]).toHaveValue('100')
+  //     await waitFor(() => {
+  //       expect(onChangeMock).toHaveBeenCalledWith([10, propsMock.max])
+  //     })
+  //   })
+
+  it('should not update prices when input is blurred and value in input has not changed', async () => {
+    const inputs = screen.getAllByRole('textbox')
+
+    await userEvent.click(inputs[0])
+    await userEvent.tab()
+
+    await waitFor(() => {
+      expect(onChangeMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/tests/unit/components/app-range/AppRange.spec.jsx
+++ b/src/tests/unit/components/app-range/AppRange.spec.jsx
@@ -1,14 +1,32 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import AppRange from '~/components/app-range/AppRange'
 
-const onChangeMock = vi.fn()
+import AppRange from '~/components/app-range/AppRange'
+import * as utils from '~/utils/range-filter'
+
+vi.mock('~/utils/range-filter', async () => {
+  const actual = await vi.importActual('~/utils/range-filter')
+  return {
+    ...actual,
+    checkRangeEquality: vi.fn(),
+    createMarks: vi.fn(() => {})
+  }
+})
+
+const mockCheckRangeEquality = vi.mocked(utils.checkRangeEquality)
 
 const propsMock = {
   min: 0,
   max: 100,
-  onChange: onChangeMock,
+  onChange: vi.fn(),
   value: [10, 50]
+}
+
+const changedMockProps = {
+  min: 0,
+  max: 100,
+  onChange: vi.fn(),
+  value: [20, 80]
 }
 
 describe('AppRange', () => {
@@ -37,7 +55,7 @@ describe('AppRange', () => {
 
     expect(sliders[0].value).toBe('17')
     await waitFor(() => {
-      expect(onChangeMock).toHaveBeenCalled('17')
+      expect(propsMock.onChange).toHaveBeenCalled('17')
     })
   })
 
@@ -48,7 +66,7 @@ describe('AppRange', () => {
     await userEvent.type(inputs[0], '20')
 
     await waitFor(() => {
-      expect(onChangeMock).toHaveBeenCalledWith([20, 50])
+      expect(propsMock.onChange).toHaveBeenCalledWith([20, 50])
     })
   })
 
@@ -59,7 +77,7 @@ describe('AppRange', () => {
     await userEvent.type(inputs[0], 'NaN')
 
     await waitFor(() => {
-      expect(onChangeMock).not.toHaveBeenCalled()
+      expect(propsMock.onChange).not.toHaveBeenCalled()
     })
   })
 
@@ -70,24 +88,19 @@ describe('AppRange', () => {
     await userEvent.tab()
 
     await waitFor(() => {
-      expect(onChangeMock).toHaveBeenCalledWith([propsMock.min, 50])
+      expect(propsMock.onChange).toHaveBeenCalledWith([propsMock.min, 50])
     })
   })
 
-  //   it('should update prices when input is blurred and input is greater than max value', async () => {
-  //     const inputs = screen.getAllByRole('textbox')
+  it('should update prices when input is blurred and input is greater than max value', async () => {
+    const inputs = screen.getAllByRole('textbox')
 
-  //     await userEvent.clear(inputs[1])
-  //     await userEvent.type(inputs[1], '1500000')
-  //     await userEvent.tab()
+    await userEvent.clear(inputs[1])
+    await userEvent.type(inputs[1], '1500000')
+    await userEvent.tab()
 
-  //     expect(inputs[1]).not.toHaveFocus()
-
-  //     expect(inputs[1]).toHaveValue('100')
-  //     await waitFor(() => {
-  //       expect(onChangeMock).toHaveBeenCalledWith([10, propsMock.max])
-  //     })
-  //   })
+    expect(inputs[1]).toHaveValue('100')
+  })
 
   it('should not update prices when input is blurred and value in input has not changed', async () => {
     const inputs = screen.getAllByRole('textbox')
@@ -96,7 +109,16 @@ describe('AppRange', () => {
     await userEvent.tab()
 
     await waitFor(() => {
-      expect(onChangeMock).not.toHaveBeenCalled()
+      expect(propsMock.onChange).not.toHaveBeenCalled()
     })
+  })
+
+  it('should call setRange with defaultValue if checkRangeEquality returns true', () => {
+    mockCheckRangeEquality.mockReturnValue(true)
+
+    const { rerender } = render(<AppRange {...propsMock} />)
+    rerender(<AppRange {...changedMockProps} />)
+
+    expect(mockCheckRangeEquality).toHaveBeenCalledWith([10, 50], [20, 80])
   })
 })


### PR DESCRIPTION
Write tests for range component (#189).
In the test "it should call onChange when slider is moved", 'fireEvent' was used because 'userEvent' does not support controlling an input of type 'range'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added comprehensive unit tests for the `AppRange` component
	- Verified component rendering, user interactions, and input validations
	- Tested slider movements, input changes, and edge cases
	- Ensured proper handling of numeric and non-numeric inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->