### PR TITLE
Display registration errors in UI (#351)

### DIFF
--- a/src/containers/guest-home-page/signup-dialog/SignUpDialog.tsx
+++ b/src/containers/guest-home-page/signup-dialog/SignUpDialog.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import SignUpForm from '~/containers/guest-home-page/signup-form/SignUpForm'
 import GoogleLogin from '~/containers/guest-home-page/google-login/GoogleLogin'
 import { useModalContext, CLOSE_EVENT_KEY } from '~/context/modal-context'
+import { useSnackBarContext } from '~/context/snackbar-context'
 
 import tutorImg from '~/assets/img/signup-dialog/tutor.svg'
 import studentImg from '~/assets/img/signup-dialog/student.svg'
@@ -28,10 +29,17 @@ import { useSignUpMutation } from '~/services/auth-service'
 
 import styles from './SignUpDialog.styles'
 
+export interface ErrorResponse {
+  code?: string
+  message?: string
+  status?: number
+}
+
 const SignUpDialog: FC<SignUpDialogProps> = ({ initialRole }) => {
   const { t } = useTranslation()
   const { closeModal, registerEvent, unregisterEvent } = useModalContext()
   const { openDialog } = useConfirm()
+  const { setAlert } = useSnackBarContext()
   const [signUp] = useSignUpMutation()
 
   const closeConfirmation = useCallback(
@@ -67,9 +75,29 @@ const SignUpDialog: FC<SignUpDialogProps> = ({ initialRole }) => {
                 : UserRoleEnum.Student
           }).unwrap()
 
-          alert('Registration successful!')
+          setAlert({
+            severity: 'success',
+            message: t('signup.success')
+          })
           closeModal(true)
-        } catch (err) {
+        } catch (err: unknown) {
+          const errorResponse = err as ErrorResponse
+
+          let errorMessage = t('errors.UNKNOWN_ERROR')
+
+          if (errorResponse?.code) {
+            errorMessage = t(`errors.${errorResponse.code}`, {
+              defaultValue: t('errors.UNKNOWN_ERROR')
+            })
+          } else if (errorResponse?.status === 409) {
+            errorMessage = t('errors.ALREADY_REGISTERED')
+          }
+
+          setAlert({
+            severity: 'error',
+            message: errorMessage
+          })
+
           console.error('Registration error:', err)
         }
       },


### PR DESCRIPTION
#### What’s Implemented?
 **Added error handling using `SnackbarContext`** for clear user notifications.  
 **Handled various error scenarios:**  
   - If the server returns an error code, the message is retrieved from `errors.json`.  
   - If the email is already registered (`409 Conflict`), the message `"errors.ALREADY_REGISTERED"` is displayed.  
   - If no specific error code is received, the `"errors.UNKNOWN_ERROR"` message is shown.  
 **Replaced `alert()` with `Snackbar` notifications** for success and error messages.  
 **Tested the implementation by attempting to register with an already registered email.**  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the sign-up experience with improved notifications: users now receive clearer alerts for successful registrations and more precise error messages when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->