### PR TITLE
Replace alert with InfoPopUpModal for email confirmation (#348)

### DIFF
--- a/src/containers/guest-home-page/info-pop-up-modal/InfoPopUpModal.tsx
+++ b/src/containers/guest-home-page/info-pop-up-modal/InfoPopUpModal.tsx
@@ -3,13 +3,18 @@ import imgInfo from '~/assets/img/guest-home-page/info.svg'
 import { useTranslation } from 'react-i18next'
 import { useModalContext } from '~/context/modal-context'
 
-export default function InfoPopUpModal() {
+interface InfoPopUpModalProps {
+  email: string
+}
+
+export default function InfoPopUpModal({ email }: InfoPopUpModalProps) {
   const { t } = useTranslation()
   const { closeModal } = useModalContext()
+
   return (
     <NotificationModal
       buttonTitle={t('common.confirmButton')}
-      description={`${t('signup.confirmEmailMessage')} Your email ${t('signup.confirmEmailDesc')}`}
+      description={`${t('signup.confirmEmailMessage')} ${email}. ${t('signup.confirmEmailDesc')}`}
       img={imgInfo}
       onClose={closeModal}
       title={t('signup.confirmEmailTitle')}

--- a/src/containers/guest-home-page/signup-dialog/SignUpDialog.tsx
+++ b/src/containers/guest-home-page/signup-dialog/SignUpDialog.tsx
@@ -28,6 +28,7 @@ import { UserRoleEnum } from '~/types'
 import { useSignUpMutation } from '~/services/auth-service'
 
 import styles from './SignUpDialog.styles'
+import InfoPopUpModal from '../info-pop-up-modal/InfoPopUpModal'
 
 export interface ErrorResponse {
   code?: string
@@ -37,7 +38,8 @@ export interface ErrorResponse {
 
 const SignUpDialog: FC<SignUpDialogProps> = ({ initialRole }) => {
   const { t } = useTranslation()
-  const { closeModal, registerEvent, unregisterEvent } = useModalContext()
+  const { openModal, closeModal, registerEvent, unregisterEvent } =
+    useModalContext()
   const { openDialog } = useConfirm()
   const { setAlert } = useSnackBarContext()
   const [signUp] = useSignUpMutation()
@@ -75,11 +77,9 @@ const SignUpDialog: FC<SignUpDialogProps> = ({ initialRole }) => {
                 : UserRoleEnum.Student
           }).unwrap()
 
-          setAlert({
-            severity: 'success',
-            message: t('signup.success')
+          openModal({
+            component: <InfoPopUpModal email={data.email} />
           })
-          closeModal(true)
         } catch (err: unknown) {
           const errorResponse = err as ErrorResponse
 


### PR DESCRIPTION
##  Description
This PR replaces the simple alert with a `InfoPopUpModal` after successful registration. Instead of a snackbar alert, users will now see a modal notifying them that a confirmation email has been sent to their email address.

## 🔹 Implementation Details
- **Removed:** `alert('Registration successful!')`
- **Added:** `InfoPopUpModal` to display a confirmation message
- **Passed:** `userEmail` as a prop to `InfoPopUpModal`
- **Updated:** Modal button now **closes the modal and redirects the user to the home page `/`**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The registration process now provides enhanced feedback by displaying a pop-up that dynamically shows your submitted email.
  - The modal management has been updated to replace the static success alert with a more informative email confirmation pop-up during sign-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->