### PR TITLE
Refactor Custom Hooks for Pagination (#387)

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,7 +19,17 @@ export const snackbarVariants: { [key: string]: AlertColor } = {
 export const defaultResponses = {
   array: [],
   object: {},
-  itemsWithCount: { count: 0, items: [] }
+  itemsWithCount: {
+    data: [],
+    pagination: {
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: 0,
+      itemsPerPage: 10,
+      hasNextPage: false,
+      hasPrevPage: false
+    }
+  }
 }
 
 export const itemsLoadLimit = {

--- a/src/hooks/use-categories-names.tsx
+++ b/src/hooks/use-categories-names.tsx
@@ -1,22 +1,37 @@
 import { useCallback } from 'react'
-import { defaultResponses } from '~/constants'
-
 import useAxios from '~/hooks/use-axios'
+import { defaultResponses } from '~/constants'
 import { categoryService } from '~/services/category-service'
-import { CategoryNameInterface } from '~/types'
+import { ErrorResponse, ItemsWithCount, CategoryNameInterface } from '~/types'
 
-const useCategoriesNames = ({ fetchOnMount = true } = {}) => {
-  const getCategoriesNames = useCallback(
-    () => categoryService.getCategoriesNames(),
-    []
-  )
+interface UseCategoriesNamesProps {
+  page?: number
+  limit?: number
+  fetchOnMount?: boolean
+}
+
+interface UseCategoriesNamesResult {
+  loading: boolean
+  response: ItemsWithCount<CategoryNameInterface>
+  fetchData: () => Promise<void>
+  error: ErrorResponse | null
+}
+
+const useCategoriesNames = ({
+  page = 1,
+  limit = 10,
+  fetchOnMount = true
+}: UseCategoriesNamesProps = {}): UseCategoriesNamesResult => {
+  const getCategoriesNames = useCallback(() => {
+    return categoryService.getCategoriesNames(page, limit)
+  }, [page, limit])
 
   const { loading, response, fetchData, error } = useAxios<
-    CategoryNameInterface[]
+    ItemsWithCount<CategoryNameInterface>
   >({
     service: getCategoriesNames,
     fetchOnMount,
-    defaultResponse: defaultResponses.array
+    defaultResponse: defaultResponses.itemsWithCount
   })
 
   return { loading, response, fetchData, error }

--- a/src/hooks/use-load-more.tsx
+++ b/src/hooks/use-load-more.tsx
@@ -16,24 +16,28 @@ const useLoadMore = <Data, Params>({
   limit,
   params
 }: UseLoadMoreProps<Data, Params>) => {
-  const [skip, setSkip] = useState<number>(0)
+  const [page, setPage] = useState<number>(1)
   const [data, setData] = useState<Data[]>([])
   const [previousLimit, setPreviousLimit] = useState<number>(limit)
+  const [hasNextPage, setHasNextPage] = useState<boolean>(true)
 
   let isFetched = false
 
-  const loadMore = useCallback(
-    () => setSkip((prevState) => prevState + limit),
-    [limit]
-  )
+  const loadMore = useCallback(() => {
+    if (hasNextPage) {
+      setPage((prevPage) => prevPage + 1)
+    }
+  }, [hasNextPage])
 
   const handleResponse = useCallback((responseData: ItemsWithCount<Data>) => {
-    setData((prevState) => [...prevState, ...responseData.items])
+    setData((prevState) => [...prevState, ...responseData.data])
+    setHasNextPage(responseData.pagination?.hasNextPage ?? false)
   }, [])
 
   const resetData = useCallback(() => {
-    setSkip(0)
+    setPage(1)
     setData([])
+    setHasNextPage(true)
   }, [])
 
   const { response, loading, fetchData } = useAxios<
@@ -48,7 +52,7 @@ const useLoadMore = <Data, Params>({
 
   useLayoutEffect(() => {
     if (previousLimit === limit && !isFetched) {
-      void fetchData({ ...params, limit, skip } as Params)
+      void fetchData({ ...params, limit, page } as Params)
     } else {
       resetData()
       setPreviousLimit(limit)
@@ -58,12 +62,11 @@ const useLoadMore = <Data, Params>({
       // eslint-disable-next-line react-hooks/exhaustive-deps
       isFetched = true
     }
-  }, [fetchData, limit, previousLimit, resetData, skip, params])
+  }, [fetchData, limit, previousLimit, resetData, page, params])
 
-  const isExpandable = useMemo(
-    () => data.length < response.count && data.length > 0,
-    [data, response]
-  )
+  const isExpandable = useMemo(() => hasNextPage, [hasNextPage])
+
+  console.log(response, 'response')
 
   return {
     data,

--- a/src/hooks/use-subjects-names.tsx
+++ b/src/hooks/use-subjects-names.tsx
@@ -1,42 +1,39 @@
 import { useCallback } from 'react'
-import { defaultResponses } from '~/constants'
-
 import useAxios from '~/hooks/use-axios'
+import { defaultResponses } from '~/constants'
 import { subjectService } from '~/services/subject-service'
-import { ErrorResponse, SubjectNameInterface } from '~/types'
+import { ErrorResponse, ItemsWithCount, SubjectNameInterface } from '~/types'
 
-interface UseSubjectsNamesProps<T> {
+interface UseSubjectsNamesProps {
   category: string | null
+  page?: number
+  limit?: number
   fetchOnMount?: boolean
-  transform?: (data: SubjectNameInterface[]) => T[]
 }
 
-interface UseSubjectsNamesResult<T> {
+interface UseSubjectsNamesResult {
   loading: boolean
-  response: T[]
+  response: ItemsWithCount<SubjectNameInterface>
   fetchData: () => Promise<void>
   error: ErrorResponse | null
 }
 
-const useSubjectsNames = <T = SubjectNameInterface,>({
+const useSubjectsNames = ({
   category,
-  fetchOnMount = true,
-  transform
-}: UseSubjectsNamesProps<T>): UseSubjectsNamesResult<T> => {
-  const getSubjectsNames = useCallback(
-    () => subjectService.getSubjectsNames(category),
-    [category]
-  )
+  page = 1,
+  limit = 10,
+  fetchOnMount = true
+}: UseSubjectsNamesProps): UseSubjectsNamesResult => {
+  const getSubjectsNames = useCallback(() => {
+    return subjectService.getSubjectsNames(category, page, limit)
+  }, [category, page, limit])
 
   const { loading, response, fetchData, error } = useAxios<
-    SubjectNameInterface[],
-    undefined,
-    T[]
+    ItemsWithCount<SubjectNameInterface>
   >({
     service: getSubjectsNames,
     fetchOnMount,
-    defaultResponse: defaultResponses.array,
-    transform
+    defaultResponse: defaultResponses.itemsWithCount
   })
 
   return { loading, response, fetchData, error }

--- a/src/services/category-service.ts
+++ b/src/services/category-service.ts
@@ -1,6 +1,5 @@
 import { axiosClient } from '~/plugins/axiosClient'
 import { AxiosResponse } from 'axios'
-
 import { URLs } from '~/constants/request'
 import {
   CategoryInterface,
@@ -15,7 +14,12 @@ export const categoryService = {
   ): Promise<AxiosResponse<ItemsWithCount<CategoryInterface>>> => {
     return axiosClient.get(URLs.categories.get, { params })
   },
-  getCategoriesNames: (): Promise<AxiosResponse<CategoryNameInterface[]>> => {
-    return axiosClient.get(URLs.categories.getNames)
+  getCategoriesNames: (
+    page?: number,
+    limit?: number
+  ): Promise<AxiosResponse<ItemsWithCount<CategoryNameInterface>>> => {
+    return axiosClient.get(URLs.categories.getNames, {
+      params: { page, limit }
+    })
   }
 }

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -1,6 +1,5 @@
 import { axiosClient } from '~/plugins/axiosClient'
 import { AxiosResponse } from 'axios'
-
 import { URLs } from '~/constants/request'
 import { ItemsWithCount, SubjectInterface, SubjectNameInterface } from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
@@ -14,9 +13,13 @@ export const subjectService = {
     return axiosClient.get(`${category}${URLs.subjects.get}`, { params })
   },
   getSubjectsNames: (
-    categoryId: string | null
-  ): Promise<AxiosResponse<SubjectNameInterface[]>> => {
+    categoryId: string | null,
+    page?: number,
+    limit?: number
+  ): Promise<AxiosResponse<ItemsWithCount<SubjectNameInterface>>> => {
     const category = createUrlPath(URLs.categories.get, categoryId)
-    return axiosClient.get(`${category}${URLs.subjects.getNames}`)
+    return axiosClient.get(`${category}${URLs.subjects.getNames}`, {
+      params: { page, limit }
+    })
   }
 }

--- a/src/tests/unit/hooks/use-categories-names.spec.jsx
+++ b/src/tests/unit/hooks/use-categories-names.spec.jsx
@@ -2,13 +2,24 @@ import { vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import useCategoriesNames from '~/hooks/use-categories-names'
 import { categoryService } from '~/services/category-service'
+import { defaultResponses } from '~/constants'
 
 vi.mock('~/services/category-service')
 
-const mockCategoriesNames = [
-  { _id: '1', name: 'Category 1' },
-  { _id: '2', name: 'Category 2' }
-]
+const mockCategoriesNames = {
+  data: [
+    { _id: '1', name: 'Category 1' },
+    { _id: '2', name: 'Category 2' }
+  ],
+  pagination: {
+    currentPage: 1,
+    totalPages: 1,
+    totalItems: 2,
+    itemsPerPage: 10,
+    hasNextPage: false,
+    hasPrevPage: false
+  }
+}
 
 const mockError = {
   status: 404,
@@ -25,11 +36,10 @@ describe('useCategoriesNames', () => {
     const { result } = renderHook(() => useCategoriesNames())
 
     expect(result.current.loading).toBe(true)
-    expect(result.current.response).toEqual([])
+    expect(result.current.response).toEqual(defaultResponses.itemsWithCount)
 
-    waitFor(() => {
-      expect(categoryService.getCategoriesNames).toHaveBeenCalled()
-
+    await waitFor(() => {
+      expect(categoryService.getCategoriesNames).toHaveBeenCalledWith(1, 10)
       expect(result.current.loading).toBe(false)
       expect(result.current.response).toEqual(mockCategoriesNames)
     })
@@ -43,13 +53,12 @@ describe('useCategoriesNames', () => {
     const { result } = renderHook(() => useCategoriesNames())
 
     expect(result.current.loading).toBe(true)
-    expect(result.current.response).toEqual([])
+    expect(result.current.response).toEqual(defaultResponses.itemsWithCount)
 
-    waitFor(() => {
-      expect(categoryService.getCategoriesNames).toHaveBeenCalled()
-
+    await waitFor(() => {
+      expect(categoryService.getCategoriesNames).toHaveBeenCalledWith(1, 10)
       expect(result.current.loading).toBe(false)
-      expect(result.current.error).toBe(mockError)
+      expect(result.current.error).toEqual(mockError)
     })
   })
 })

--- a/src/tests/unit/hooks/use-categories-names.spec.jsx
+++ b/src/tests/unit/hooks/use-categories-names.spec.jsx
@@ -1,5 +1,5 @@
 import { vi } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
 import useCategoriesNames from '~/hooks/use-categories-names'
 import { categoryService } from '~/services/category-service'
 import { defaultResponses } from '~/constants'
@@ -27,6 +27,11 @@ const mockError = {
   message: 'The requested URL was not found.'
 }
 
+afterEach(() => {
+  vi.clearAllMocks()
+  cleanup()
+})
+
 describe('useCategoriesNames', () => {
   it('fetches categories names successfully', async () => {
     categoryService.getCategoriesNames.mockResolvedValueOnce({
@@ -38,11 +43,14 @@ describe('useCategoriesNames', () => {
     expect(result.current.loading).toBe(true)
     expect(result.current.response).toEqual(defaultResponses.itemsWithCount)
 
-    await waitFor(() => {
-      expect(categoryService.getCategoriesNames).toHaveBeenCalledWith(1, 10)
-      expect(result.current.loading).toBe(false)
-      expect(result.current.response).toEqual(mockCategoriesNames)
-    })
+    await waitFor(
+      () => {
+        expect(categoryService.getCategoriesNames).toHaveBeenCalledWith(1, 10)
+        expect(result.current.loading).toBe(false)
+        expect(result.current.response).toEqual(mockCategoriesNames)
+      },
+      { timeout: 5000 }
+    )
   })
 
   it('handles API errors', async () => {
@@ -55,10 +63,13 @@ describe('useCategoriesNames', () => {
     expect(result.current.loading).toBe(true)
     expect(result.current.response).toEqual(defaultResponses.itemsWithCount)
 
-    await waitFor(() => {
-      expect(categoryService.getCategoriesNames).toHaveBeenCalledWith(1, 10)
-      expect(result.current.loading).toBe(false)
-      expect(result.current.error).toEqual(mockError)
-    })
+    await waitFor(
+      () => {
+        expect(categoryService.getCategoriesNames).toHaveBeenCalledWith(1, 10)
+        expect(result.current.loading).toBe(false)
+        expect(result.current.error).toEqual(mockError)
+      },
+      { timeout: 5000 }
+    )
   })
 })

--- a/src/tests/unit/hooks/use-subjects-names.spec.jsx
+++ b/src/tests/unit/hooks/use-subjects-names.spec.jsx
@@ -1,14 +1,24 @@
 import { vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import useSubjects from '~/hooks/use-subjects-names'
+import useSubjectsNames from '~/hooks/use-subjects-names'
 import { subjectService } from '~/services/subject-service'
 
 vi.mock('~/services/subject-service')
 
-const mockSubjectsNames = [
-  { _id: '1', name: 'Subject 1' },
-  { _id: '2', name: 'Subject 2' }
-]
+const mockSubjectsNames = {
+  data: [
+    { _id: '1', name: 'Subject 1' },
+    { _id: '2', name: 'Subject 2' }
+  ],
+  pagination: {
+    currentPage: 1,
+    totalPages: 1,
+    totalItems: 2,
+    itemsPerPage: 10,
+    hasNextPage: false,
+    hasPrevPage: false
+  }
+}
 
 const mockError = {
   status: 404,
@@ -22,11 +32,17 @@ describe('useSubjectsNames', () => {
       data: mockSubjectsNames
     })
 
-    const { result } = renderHook(() => useSubjects({ category: 'category' }))
+    const { result } = renderHook(() =>
+      useSubjectsNames({ category: 'category' })
+    )
 
-    expect(subjectService.getSubjectsNames).toHaveBeenCalledWith('category')
+    expect(subjectService.getSubjectsNames).toHaveBeenCalledWith(
+      'category',
+      1,
+      10
+    )
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(result.current.loading).toBe(false)
       expect(result.current.response).toEqual(mockSubjectsNames)
     })
@@ -34,16 +50,20 @@ describe('useSubjectsNames', () => {
 
   it('handles API errors', async () => {
     subjectService.getSubjectsNames.mockRejectedValueOnce({
-      response: {
-        data: mockError
-      }
+      response: { data: mockError }
     })
 
-    const { result } = renderHook(() => useSubjects({ category: 'category' }))
+    const { result } = renderHook(() =>
+      useSubjectsNames({ category: 'category' })
+    )
 
-    expect(subjectService.getSubjectsNames).toHaveBeenCalledWith('category')
+    expect(subjectService.getSubjectsNames).toHaveBeenCalledWith(
+      'category',
+      1,
+      10
+    )
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(result.current.loading).toBe(false)
       expect(result.current.error).toEqual(mockError)
     })

--- a/src/tests/unit/hooks/use-subjects-names.spec.jsx
+++ b/src/tests/unit/hooks/use-subjects-names.spec.jsx
@@ -1,5 +1,5 @@
 import { vi } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
 import useSubjectsNames from '~/hooks/use-subjects-names'
 import { subjectService } from '~/services/subject-service'
 
@@ -26,6 +26,11 @@ const mockError = {
   message: 'The requested URL was not found.'
 }
 
+afterEach(() => {
+  vi.clearAllMocks()
+  cleanup()
+})
+
 describe('useSubjectsNames', () => {
   it('fetches subjects with a category successfully', async () => {
     subjectService.getSubjectsNames.mockResolvedValueOnce({
@@ -42,10 +47,13 @@ describe('useSubjectsNames', () => {
       10
     )
 
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false)
-      expect(result.current.response).toEqual(mockSubjectsNames)
-    })
+    await waitFor(
+      () => {
+        expect(result.current.loading).toBe(false)
+        expect(result.current.response).toEqual(mockSubjectsNames)
+      },
+      { timeout: 5000 }
+    )
   })
 
   it('handles API errors', async () => {
@@ -63,9 +71,12 @@ describe('useSubjectsNames', () => {
       10
     )
 
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false)
-      expect(result.current.error).toEqual(mockError)
-    })
+    await waitFor(
+      () => {
+        expect(result.current.loading).toBe(false)
+        expect(result.current.error).toEqual(mockError)
+      },
+      { timeout: 5000 }
+    )
   })
 })

--- a/src/types/common/interfaces/common.interfaces.ts
+++ b/src/types/common/interfaces/common.interfaces.ts
@@ -7,10 +7,20 @@ import {
   UserRoleEnum
 } from '~/types'
 
-export interface ItemsWithCount<T> {
-  count: number
-  items: T[]
+export interface Pagination {
+  currentPage: number
+  totalPages: number
+  totalItems: number
+  itemsPerPage: number
+  hasNextPage: boolean
+  hasPrevPage: boolean
 }
+
+export interface ItemsWithCount<T> {
+  data: T[]
+  pagination: Pagination
+}
+
 export interface CommonEntityFields {
   _id: string
   createdAt: Date


### PR DESCRIPTION
## Description

This pull request refactors our custom hooks to properly support paginated responses from the backend. The backend now returns responses in the following format:

```json
{
  "pagination": {
    "currentPage": number,
    "totalPages": number,
    "totalItems": number,
    "itemsPerPage": number,
    "hasNextPage": boolean,
    "hasPrevPage": boolean
  },
  "data": [ ... ]
}
```

#### Our changes ensure that:

- The correct page and limit parameters are passed to the API.
- The response is correctly processed and merged into the component state.
- Type definitions and default responses reflect the new data structure.

## Changes Made
### 1. Type Definitions
`ItemsWithCount<T>`Interface

Updated to include:

- `data: T[]` – Array of items.
- `pagination` – An object with pagination details:
- `currentPage`
- `totalPages`
- `totalItems`
- `itemsPerPage`
- `hasNextPage`
- `hasPrevPage`

`Pagination` Interface
Defined to represent the pagination data structure.

### 2. Default Responses

Updated `defaultResponses.itemsWithCount` to:

```ts
export const defaultResponses = {
  itemsWithCount: {
    data: [],
    pagination: {
      currentPage: 1,
      totalPages: 1,
      totalItems: 0,
      itemsPerPage: 10,
      hasNextPage: false,
      hasPrevPage: false
    }
  },
  // ...other defaults
};
```
This ensures that the default value matches the expected structure.

### 3. Custom Hooks

#### useLoadMore Hook
- Maintains local state for `page`, `data`, and `hasNextPage`.
- Increments the page number when `loadMore` is called.
- The `handleResponse` callback appends new items to the existing data and updates the `hasNextPage` flag based on the backend response.
- Passes `{ ...params, limit, page }` to the service function via `useAxios`.

#### useCategoriesNames Hook
- Accepts `page` and `limit` parameters (with default values) and passes them to `categoryService.getCategoriesNames`.
- Uses `useAxios` to handle the paginated response, expecting the structure of `ItemsWithCount<CategoryNameInterface>`.

#### useSubjectsNames Hook
- Accepts a `category` identifier along with `page` and `limit` parameters.
- Calls `subjectService.getSubjectsNames` with these parameters.
- Processes the response similarly to `useCategoriesNames`.

---

### 4. Service Functions

#### categoryService.getCategoriesNames
- Now accepts `page` and `limit` as parameters.
- Passes these parameters to the backend via the request’s query string.

#### subjectService.getSubjectsNames
- Similarly updated to accept `categoryId`, `page`, and `limit`.
- Sends the query parameters to the backend so that it returns a paginated response.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pagination support for category and subject listings, providing detailed navigation information for a smoother browsing experience.
	- Optimized data loading and "load more" functionality, ensuring intuitive and efficient content exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->